### PR TITLE
Bug fix in Audio.sh

### DIFF
--- a/root/scripts/Audio.sh
+++ b/root/scripts/Audio.sh
@@ -1808,7 +1808,7 @@ CheckLidarrBeforeImport () {
 
 		if [ "$wantedAlbumListSource" == "cutoff" ]; then
 			checkLidarrAlbumFiles="$(curl -s "$lidarrUrl/api/v1/trackFile?albumId=$1?apikey=${lidarrApiKey}")"
-			checkLidarrAlbumQualityCutoffNotMet=$(echo "$checkLidarrAlbumData" | jq -r ".[].qualityCutoffNotMet")
+			checkLidarrAlbumQualityCutoffNotMet=$(echo "$checkLidarrAlbumFiles" | jq -r ".[].qualityCutoffNotMet")
 			if echo "$checkLidarrAlbumQualityCutoffNotMet" | grep "true" | read; then
 				log "$page :: $wantedAlbumListSource :: $processNumber of $wantedListAlbumTotal :: $lidarrArtistName :: $lidarrAlbumTitle :: $lidarrAlbumType :: Already Imported Album (CutOff - $checkLidarrAlbumQualityCutoffNotMet), skipping..."
 				alreadyImported=true


### PR DESCRIPTION
Looks like some copy-pasta. Prior to this fix I would see lots of errors in the Audio.log such as: `jq: error (at <stdin>:418): Cannot index string with string "qualityCutoffNotMet"`.  With the fix the cutoff related code does what it is supposed to.